### PR TITLE
Set Secure and HttpOnly to authservice_session

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -198,6 +198,8 @@ func (s *server) callback(w http.ResponseWriter, r *http.Request) {
 	session := sessions.NewSession(s.store, userSessionCookie)
 	session.Options.MaxAge = s.sessionMaxAgeSeconds
 	session.Options.Path = "/"
+	session.Options.Secure = true
+	session.Options.HttpOnly = true
 
 	session.Values[userSessionUserID] = claims[s.userIDOpts.claim].(string)
 	session.Values[userSessionClaims] = claims


### PR DESCRIPTION
Restrict access to cookie, as requested by AVA.
From my understanding, both attribute should be used. 
Resolves https://github.com/StatCan/daaas/issues/353 (part of it)